### PR TITLE
Prompts user to press 'START' on successful kernel hook.

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
 	ret = udsploit();
 	printf("%08X\n", (unsigned int)ret);
 	if(ret) goto fail;
-	
+
 	printf("udsploit success\n");
 
 	ret = hook_kernel();
@@ -41,6 +41,7 @@ int main(int argc, char **argv)
 		gfxSwapBuffers();
 	}
 
+	printf("Press 'START' to continue.")
 	gfxExit();
 	return 0;
 }


### PR DESCRIPTION
Saw someone post something about this in Issues so I thought I would add a quick print that prompts the user to, on kernel_hook() success, press 'START' to proceed with their installation. I came here looking for a similar answer!

I'm not familiar with the particulars of your stack so I placed the print in a cautious location just before the program exits and, presumably, after we succeed rather than fail.

Of course, feel free to place it where you like.